### PR TITLE
fix(client): make workflow-gen-prefix work on starting workflows and not just child workflows

### DIFF
--- a/internal/generator/client.go
+++ b/internal/generator/client.go
@@ -127,16 +127,18 @@ func Client(gf *protogen.GeneratedFile, service *protogen.Service, config *Confi
 						g.Add(jen.Id("wOptions").Dot("TaskQueue").Op("=").Id(fmt.Sprintf("Default%sTaskQueueName", service.GoName)))
 					}))
 
-					g.Add(
-						jen.If(jen.Id("wOptions").Dot("ID").Op("==").Lit("")).BlockFunc(func(g *jen.Group) {
-							g.Add(jen.Id("wOptions").Dot("ID").Op("=").Id(getFmtObject(gf, "Sprintf")).CallFunc(func(g *jen.Group) {
-								g.Add(jen.Lit("%s/%s"))
-								g.Add(jen.Lit(methName))
-								g.Add(jen.Id(getUUIDObject(gf, "NewString")).Parens(jen.Null()))
-							}))
-						},
-						),
-					)
+					if config.GenWorkflowPrefix {
+						g.Add(
+							jen.If(jen.Id("wOptions").Dot("ID").Op("==").Lit("")).BlockFunc(func(g *jen.Group) {
+								g.Add(jen.Id("wOptions").Dot("ID").Op("=").Id(getFmtObject(gf, "Sprintf")).CallFunc(func(g *jen.Group) {
+									g.Add(jen.Lit("%s/%s"))
+									g.Add(jen.Lit(methName))
+									g.Add(jen.Id(getUUIDObject(gf, "NewString")).Parens(jen.Null()))
+								}))
+							},
+							),
+						)
+					}
 
 					if workflowOptions != nil {
 						if workflowOptions.WorkflowExecutionTimeout != nil {


### PR DESCRIPTION
Up until now the check on the config value was only performed on the ChildWorkflow call, and not starting a workflow from the client