### PR TITLE
fix(DOCS): fix a docs render bug

### DIFF
--- a/gen/example/v1/example_tmprl_doc.md
+++ b/gen/example/v1/example_tmprl_doc.md
@@ -45,13 +45,13 @@ Service Orders is a small e-commerce style fulfillment service used as a
 ### Default workflow options
 | Option | Value |
 | --- | --- |
-| Workflow execution timeout | 0s |
+| Workflow execution timeout | 1h0m0s |
 
 ### Default activity options
 | Option | Value |
 | --- | --- |
-| Schedule to close timeout | 0s |
-| Start to close timeout | 0s |
+| Schedule to close timeout | 5m0s |
+| Start to close timeout | 30s |
 
 ### Workflows
 <a id="method_example_v1_Orders_ProcessOrder"></a>

--- a/internal/model/service.go
+++ b/internal/model/service.go
@@ -276,6 +276,31 @@ func (s *Service) GetDefaultActivityTimeoutConstName() string {
 	return fmt.Sprintf("Default%sActivityScheduleToCloseTimeout", s.GoName)
 }
 
+// ResolvedDefaultActivityOptions Returns the service-level default activity
+// options with the proto's second-valued fields converted to time.Duration,
+// or nil if the service declares none. The documentation template renders from
+// this rather than reading DefaultActivityOptions directly: the raw proto
+// timeouts are *int32, which FormatDuration cannot interpret and would render
+// as 0s. Reusing MergeActivityOptions keeps the doc path on the same
+// seconds-to-Duration conversion the code generator uses.
+func (s *Service) ResolvedDefaultActivityOptions() *ActivityOptions {
+	if s.DefaultActivityOptions == nil {
+		return nil
+	}
+	return MergeActivityOptions(nil, s.DefaultActivityOptions, 0)
+}
+
+// ResolvedDefaultWorkflowOptions Returns the service-level default workflow
+// options with the proto's second-valued fields converted to time.Duration,
+// or nil if the service declares none. See ResolvedDefaultActivityOptions for
+// why the documentation template renders from this rather than the raw proto.
+func (s *Service) ResolvedDefaultWorkflowOptions() *WorkflowOptions {
+	if s.DefaultWorkflowOptions == nil {
+		return nil
+	}
+	return MergeWorkflowOptions(nil, s.DefaultWorkflowOptions)
+}
+
 // GetScheduleMergeFuncName Returns the name of the per-service helper that
 // merges user-supplied client.ScheduleOptions into a base struct.
 func (s *Service) GetScheduleMergeFuncName() string {

--- a/internal/model/service_test.go
+++ b/internal/model/service_test.go
@@ -2,6 +2,9 @@ package model
 
 import (
 	"testing"
+	"time"
+
+	temporalv1 "github.com/thomas-maurice/protoc-gen-go-tmprl/gen/temporal/v1"
 )
 
 // TestServiceGetClientName Tests client name generation
@@ -171,5 +174,65 @@ func TestServiceScheduleHelperNames(t *testing.T) {
 	}
 	if got, want := s.GetScheduleDefaultsFuncName(), "applyScheduleDefaultsDieRoll"; got != want {
 		t.Errorf("GetScheduleDefaultsFuncName() = %q, want %q", got, want)
+	}
+}
+
+// TestServiceResolvedDefaultActivityOptions guards the doc-renderer regression
+// where the "Default activity options" table rendered every timeout as 0s: the
+// proto's *int32 second fields must surface to the template as time.Duration so
+// FormatDuration humanizes them, matching what the code generator bakes in.
+func TestServiceResolvedDefaultActivityOptions(t *testing.T) {
+	i32 := func(v int32) *int32 { return &v }
+
+	if got := (&Service{}).ResolvedDefaultActivityOptions(); got != nil {
+		t.Fatalf("ResolvedDefaultActivityOptions() with no defaults = %+v, want nil", got)
+	}
+
+	s := &Service{
+		DefaultActivityOptions: &temporalv1.ActivityOptions{
+			ScheduleToStartTimeout: i32(120),
+			ScheduleToCloseTimeout: i32(3600),
+		},
+	}
+	got := s.ResolvedDefaultActivityOptions()
+	if got == nil {
+		t.Fatal("ResolvedDefaultActivityOptions() = nil, want resolved options")
+	}
+	if got.ScheduleToStartTimeout != 2*time.Minute {
+		t.Errorf("ScheduleToStartTimeout = %s, want 2m0s", got.ScheduleToStartTimeout)
+	}
+	if got.ScheduleToCloseTimeout != time.Hour {
+		t.Errorf("ScheduleToCloseTimeout = %s, want 1h0m0s", got.ScheduleToCloseTimeout)
+	}
+	// Fields the service left unset stay zero so the template omits their rows.
+	if got.StartToCloseTimeout != 0 || got.HeartbeatTimeout != 0 {
+		t.Errorf("unset timeouts = (%s, %s), want (0s, 0s)", got.StartToCloseTimeout, got.HeartbeatTimeout)
+	}
+}
+
+// TestServiceResolvedDefaultWorkflowOptions is the workflow-side counterpart to
+// TestServiceResolvedDefaultActivityOptions: the "Default workflow options"
+// table shared the same 0s bug.
+func TestServiceResolvedDefaultWorkflowOptions(t *testing.T) {
+	i32 := func(v int32) *int32 { return &v }
+
+	if got := (&Service{}).ResolvedDefaultWorkflowOptions(); got != nil {
+		t.Fatalf("ResolvedDefaultWorkflowOptions() with no defaults = %+v, want nil", got)
+	}
+
+	s := &Service{
+		DefaultWorkflowOptions: &temporalv1.WorkflowOptions{
+			WorkflowExecutionTimeout: i32(3600),
+		},
+	}
+	got := s.ResolvedDefaultWorkflowOptions()
+	if got == nil {
+		t.Fatal("ResolvedDefaultWorkflowOptions() = nil, want resolved options")
+	}
+	if got.WorkflowExecutionTimeout != time.Hour {
+		t.Errorf("WorkflowExecutionTimeout = %s, want 1h0m0s", got.WorkflowExecutionTimeout)
+	}
+	if got.WorkflowRunTimeout != 0 || got.WorkflowTaskTimeout != 0 {
+		t.Errorf("unset timeouts = (%s, %s), want (0s, 0s)", got.WorkflowRunTimeout, got.WorkflowTaskTimeout)
 	}
 }

--- a/internal/renderer/templates/documentation.tmpl
+++ b/internal/renderer/templates/documentation.tmpl
@@ -43,41 +43,41 @@
 | --- | --- |
 | Default task queue | `{{.TaskQueue}}` |
 
-{{- if .DefaultWorkflowOptions}}
-{{- if or .DefaultWorkflowOptions.WorkflowExecutionTimeout .DefaultWorkflowOptions.WorkflowRunTimeout .DefaultWorkflowOptions.WorkflowTaskTimeout}}
+{{- with .ResolvedDefaultWorkflowOptions}}
+{{- if or .WorkflowExecutionTimeout .WorkflowRunTimeout .WorkflowTaskTimeout}}
 
 ### Default workflow options
 | Option | Value |
 | --- | --- |
-{{- if .DefaultWorkflowOptions.WorkflowExecutionTimeout}}
-| Workflow execution timeout | {{FormatDuration .DefaultWorkflowOptions.WorkflowExecutionTimeout}} |
+{{- if .WorkflowExecutionTimeout}}
+| Workflow execution timeout | {{FormatDuration .WorkflowExecutionTimeout}} |
 {{- end}}
-{{- if .DefaultWorkflowOptions.WorkflowRunTimeout}}
-| Workflow run timeout | {{FormatDuration .DefaultWorkflowOptions.WorkflowRunTimeout}} |
+{{- if .WorkflowRunTimeout}}
+| Workflow run timeout | {{FormatDuration .WorkflowRunTimeout}} |
 {{- end}}
-{{- if .DefaultWorkflowOptions.WorkflowTaskTimeout}}
-| Workflow task timeout | {{FormatDuration .DefaultWorkflowOptions.WorkflowTaskTimeout}} |
+{{- if .WorkflowTaskTimeout}}
+| Workflow task timeout | {{FormatDuration .WorkflowTaskTimeout}} |
 {{- end}}
 {{- end}}
 {{- end}}
 
-{{- if .DefaultActivityOptions}}
-{{- if or .DefaultActivityOptions.ScheduleToCloseTimeout .DefaultActivityOptions.ScheduleToStartTimeout .DefaultActivityOptions.StartToCloseTimeout .DefaultActivityOptions.HeartbeatTimeout}}
+{{- with .ResolvedDefaultActivityOptions}}
+{{- if or .ScheduleToCloseTimeout .ScheduleToStartTimeout .StartToCloseTimeout .HeartbeatTimeout}}
 
 ### Default activity options
 | Option | Value |
 | --- | --- |
-{{- if .DefaultActivityOptions.ScheduleToCloseTimeout}}
-| Schedule to close timeout | {{FormatDuration .DefaultActivityOptions.ScheduleToCloseTimeout}} |
+{{- if .ScheduleToCloseTimeout}}
+| Schedule to close timeout | {{FormatDuration .ScheduleToCloseTimeout}} |
 {{- end}}
-{{- if .DefaultActivityOptions.ScheduleToStartTimeout}}
-| Schedule to start timeout | {{FormatDuration .DefaultActivityOptions.ScheduleToStartTimeout}} |
+{{- if .ScheduleToStartTimeout}}
+| Schedule to start timeout | {{FormatDuration .ScheduleToStartTimeout}} |
 {{- end}}
-{{- if .DefaultActivityOptions.StartToCloseTimeout}}
-| Start to close timeout | {{FormatDuration .DefaultActivityOptions.StartToCloseTimeout}} |
+{{- if .StartToCloseTimeout}}
+| Start to close timeout | {{FormatDuration .StartToCloseTimeout}} |
 {{- end}}
-{{- if .DefaultActivityOptions.HeartbeatTimeout}}
-| Heartbeat timeout | {{FormatDuration .DefaultActivityOptions.HeartbeatTimeout}} |
+{{- if .HeartbeatTimeout}}
+| Heartbeat timeout | {{FormatDuration .HeartbeatTimeout}} |
 {{- end}}
 {{- end}}
 {{- end}}


### PR DESCRIPTION
## Summary

Fixes a doc-renderer regression where `gen-docs` rendered the service-level **Default activity options** (and **Default workflow options**) tables with every timeout as `0s`, ignoring the values declared in the proto. Generated Go code was unaffected — this was documentation-only.

## Root cause

The doc template's service-default tables read the **raw proto** `*temporalv1.ActivityOptions` / `*temporalv1.WorkflowOptions`, whose timeout fields are `*int32`. `FormatDuration` → `toSeconds` only handles `int` / `int32` / `int64` / `time.Duration`; a `*int32` falls through to `default: return 0`, so every value rendered as `0s`.

The per-*method* tables were always correct because they read the resolved `model.*Options` structs, which store `time.Duration`. Only the *service-default* tables read the raw proto, so only they drifted. Introduced in the v0.1.4 jen→templates rewrite.

## Fix

- **`internal/model/service.go`** — added `ResolvedDefaultActivityOptions()` / `ResolvedDefaultWorkflowOptions()`, which convert the proto defaults to `time.Duration` via the same `Merge*Options` functions the code generator uses (no config-default injection; returns `nil` when the service declares no defaults). This points the doc path at the same resolved shape the code path uses, so they can't drift again.
- **`internal/renderer/templates/documentation.tmpl`** — both default tables now render from the resolved accessors via `{{with ...}}`. Because the gates are now on `time.Duration`, an unset (zero) timeout is correctly falsy and its row is omitted, rather than rendering `0s`.
- **`internal/model/service_test.go`** — regression tests asserting proto seconds → `time.Duration` for both accessors, and `nil` when no defaults are set.
- **`gen/example/v1/example_tmprl_doc.md`** — regenerated. The example `Orders` service now renders `1h0m0s`, `5m0s`, `30s` instead of `0s`. This committed golden file is the repo's de-facto drift guard (`make gen` + diff).

The bug report only mentioned activity options, but the workflow-default table had the identical bug and is fixed in the same change.

## Verification

`make` passes end-to-end (unit tests with `-race`, codegen, example build/verify).

Before / after for the example `Orders` service:

| | Before | After |
| --- | --- | --- |
| Workflow execution timeout | `0s` | `1h0m0s` |
| Schedule to close timeout | `0s` | `5m0s` |
| Start to close timeout | `0s` | `30s` |
