### PR TITLE
feat(schedule): generate a typed DescribeScheduleX read-back

### DIFF
--- a/example/e2e/e2e_test.go
+++ b/example/e2e/e2e_test.go
@@ -310,6 +310,36 @@ func TestScheduleCRUD(t *testing.T) {
 	t.Log("pause was idempotent (second call no-ops), unpause and delete clean: the full generated schedule lifecycle works against a real server")
 }
 
+// TestDescribeScheduleRoundTrip proves DescribeScheduleX decodes the schedule's
+// input back into the typed request. The SDK returns a schedule action's args as
+// raw, undecoded payloads, so without the generated typed describe the caller has
+// to reach into `Args[0].(*commonpb.Payload)` and FromPayload it by hand.
+func TestDescribeScheduleRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	const scheduleID = "e2e-describe-process-order"
+	req := &examplev1.ProcessOrderRequest{OrderId: "order-42", AmountCents: 1337}
+
+	if _, err := ordersClient.UpsertScheduleProcessOrder(ctx, scheduleID, req, client.ScheduleOptions{
+		Spec: client.ScheduleSpec{Intervals: []client.ScheduleIntervalSpec{{Every: time.Hour}}},
+	}); err != nil {
+		t.Fatalf("could not upsert schedule: %v", err)
+	}
+	defer func() { _ = ordersClient.DeleteScheduleProcessOrder(ctx, scheduleID) }()
+
+	got, desc, err := ordersClient.DescribeScheduleProcessOrder(ctx, scheduleID)
+	if err != nil {
+		t.Fatalf("could not describe schedule: %v", err)
+	}
+	if got.GetOrderId() != req.GetOrderId() || got.GetAmountCents() != req.GetAmountCents() {
+		t.Fatalf("decoded request mismatch: got {%q,%d}, want {%q,%d}",
+			got.GetOrderId(), got.GetAmountCents(), req.GetOrderId(), req.GetAmountCents())
+	}
+	if len(desc.Schedule.Spec.Intervals) == 0 {
+		t.Errorf("description did not surface the schedule spec")
+	}
+	t.Log("DescribeScheduleProcessOrder decoded the typed input from the raw payload and returned the full description")
+}
+
 // TestUpsertSchedulePreservesSpec is the regression guard for the CRITICAL
 // finding that UpsertScheduleX destroyed an existing schedule's spec. An upsert
 // that only changes the request (no options) used to overwrite the spec with an

--- a/gen/example/v1/example_tmprl.pb.go
+++ b/gen/example/v1/example_tmprl.pb.go
@@ -12,8 +12,10 @@ import (
 	context "context"
 	fmt "fmt"
 	uuid "github.com/google/uuid"
+	v1 "go.temporal.io/api/common/v1"
 	activity "go.temporal.io/sdk/activity"
 	client "go.temporal.io/sdk/client"
+	converter "go.temporal.io/sdk/converter"
 	temporal "go.temporal.io/sdk/temporal"
 	worker "go.temporal.io/sdk/worker"
 	workflow "go.temporal.io/sdk/workflow"
@@ -314,6 +316,47 @@ func (c *OrdersClient) CreateScheduleProcessOrder(ctx context.Context, scheduleI
 // cancelled (CancelOrder signal)
 func (c *OrdersClient) GetScheduleProcessOrder(ctx context.Context, scheduleID string) client.ScheduleHandle {
 	return c.client.ScheduleClient().GetHandle(ctx, scheduleID)
+}
+
+// DescribeScheduleProcessOrder reads a schedule for ProcessOrder and returns the
+// DECODED workflow request alongside the full schedule description (spec, policy,
+// action timeouts, paused state, ...).
+//
+// The Temporal SDK returns a schedule action's input arguments as raw, undecoded
+// payloads, so this decodes the first argument back into the workflow's request
+// type. Pass the same data converter the client was built with when the input is
+// encrypted/custom-encoded (e.g. a codec/keyring converter); omit it to use the
+// default converter. This is the typed read-back counterpart to
+// UpsertScheduleProcessOrder — useful for exporting/backing up schedules.
+func (c *OrdersClient) DescribeScheduleProcessOrder(ctx context.Context, scheduleID string, dataConverter ...converter.DataConverter) (*ProcessOrderRequest, *client.ScheduleDescription, error) {
+	handle := c.client.ScheduleClient().GetHandle(ctx, scheduleID)
+	desc, err := handle.Describe(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	action, ok := desc.Schedule.Action.(*client.ScheduleWorkflowAction)
+	if !ok {
+		return nil, desc, fmt.Errorf("schedule %q action is not a workflow action", scheduleID)
+	}
+	if len(action.Args) == 0 {
+		return nil, desc, fmt.Errorf("schedule %q has no input arguments", scheduleID)
+	}
+	payload, ok := action.Args[0].(*v1.Payload)
+	if !ok {
+		return nil, desc, fmt.Errorf("schedule %q input argument is not a raw payload (already decoded?)", scheduleID)
+	}
+
+	dc := converter.GetDefaultDataConverter()
+	if len(dataConverter) > 0 && dataConverter[0] != nil {
+		dc = dataConverter[0]
+	}
+
+	req := new(ProcessOrderRequest)
+	if err := dc.FromPayload(payload, req); err != nil {
+		return nil, desc, fmt.Errorf("decoding schedule %q input: %w", scheduleID, err)
+	}
+	return req, desc, nil
 }
 
 // DeleteScheduleProcessOrder deletes a schedule for ProcessOrder
@@ -630,6 +673,47 @@ func (c *OrdersClient) GetScheduleShipOrder(ctx context.Context, scheduleID stri
 	return c.client.ScheduleClient().GetHandle(ctx, scheduleID)
 }
 
+// DescribeScheduleShipOrder reads a schedule for ShipOrder and returns the
+// DECODED workflow request alongside the full schedule description (spec, policy,
+// action timeouts, paused state, ...).
+//
+// The Temporal SDK returns a schedule action's input arguments as raw, undecoded
+// payloads, so this decodes the first argument back into the workflow's request
+// type. Pass the same data converter the client was built with when the input is
+// encrypted/custom-encoded (e.g. a codec/keyring converter); omit it to use the
+// default converter. This is the typed read-back counterpart to
+// UpsertScheduleShipOrder — useful for exporting/backing up schedules.
+func (c *OrdersClient) DescribeScheduleShipOrder(ctx context.Context, scheduleID string, dataConverter ...converter.DataConverter) (*ShipOrderRequest, *client.ScheduleDescription, error) {
+	handle := c.client.ScheduleClient().GetHandle(ctx, scheduleID)
+	desc, err := handle.Describe(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	action, ok := desc.Schedule.Action.(*client.ScheduleWorkflowAction)
+	if !ok {
+		return nil, desc, fmt.Errorf("schedule %q action is not a workflow action", scheduleID)
+	}
+	if len(action.Args) == 0 {
+		return nil, desc, fmt.Errorf("schedule %q has no input arguments", scheduleID)
+	}
+	payload, ok := action.Args[0].(*v1.Payload)
+	if !ok {
+		return nil, desc, fmt.Errorf("schedule %q input argument is not a raw payload (already decoded?)", scheduleID)
+	}
+
+	dc := converter.GetDefaultDataConverter()
+	if len(dataConverter) > 0 && dataConverter[0] != nil {
+		dc = dataConverter[0]
+	}
+
+	req := new(ShipOrderRequest)
+	if err := dc.FromPayload(payload, req); err != nil {
+		return nil, desc, fmt.Errorf("decoding schedule %q input: %w", scheduleID, err)
+	}
+	return req, desc, nil
+}
+
 // DeleteScheduleShipOrder deletes a schedule for ShipOrder
 //
 // ShipOrder hands the package over to a courier. ProcessOrder runs it as a
@@ -937,6 +1021,47 @@ func (c *OrdersClient) CreateScheduleDailySalesReport(ctx context.Context, sched
 // schedule -- see the schedule part of the client walkthrough
 func (c *OrdersClient) GetScheduleDailySalesReport(ctx context.Context, scheduleID string) client.ScheduleHandle {
 	return c.client.ScheduleClient().GetHandle(ctx, scheduleID)
+}
+
+// DescribeScheduleDailySalesReport reads a schedule for DailySalesReport and returns the
+// DECODED workflow request alongside the full schedule description (spec, policy,
+// action timeouts, paused state, ...).
+//
+// The Temporal SDK returns a schedule action's input arguments as raw, undecoded
+// payloads, so this decodes the first argument back into the workflow's request
+// type. Pass the same data converter the client was built with when the input is
+// encrypted/custom-encoded (e.g. a codec/keyring converter); omit it to use the
+// default converter. This is the typed read-back counterpart to
+// UpsertScheduleDailySalesReport — useful for exporting/backing up schedules.
+func (c *OrdersClient) DescribeScheduleDailySalesReport(ctx context.Context, scheduleID string, dataConverter ...converter.DataConverter) (*emptypb.Empty, *client.ScheduleDescription, error) {
+	handle := c.client.ScheduleClient().GetHandle(ctx, scheduleID)
+	desc, err := handle.Describe(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	action, ok := desc.Schedule.Action.(*client.ScheduleWorkflowAction)
+	if !ok {
+		return nil, desc, fmt.Errorf("schedule %q action is not a workflow action", scheduleID)
+	}
+	if len(action.Args) == 0 {
+		return nil, desc, fmt.Errorf("schedule %q has no input arguments", scheduleID)
+	}
+	payload, ok := action.Args[0].(*v1.Payload)
+	if !ok {
+		return nil, desc, fmt.Errorf("schedule %q input argument is not a raw payload (already decoded?)", scheduleID)
+	}
+
+	dc := converter.GetDefaultDataConverter()
+	if len(dataConverter) > 0 && dataConverter[0] != nil {
+		dc = dataConverter[0]
+	}
+
+	req := new(emptypb.Empty)
+	if err := dc.FromPayload(payload, req); err != nil {
+		return nil, desc, fmt.Errorf("decoding schedule %q input: %w", scheduleID, err)
+	}
+	return req, desc, nil
 }
 
 // DeleteScheduleDailySalesReport deletes a schedule for DailySalesReport
@@ -1270,6 +1395,47 @@ func (c *OrdersClient) CreateScheduleTrackInventory(ctx context.Context, schedul
 // parked on "not enough stock" is answered before the run ends
 func (c *OrdersClient) GetScheduleTrackInventory(ctx context.Context, scheduleID string) client.ScheduleHandle {
 	return c.client.ScheduleClient().GetHandle(ctx, scheduleID)
+}
+
+// DescribeScheduleTrackInventory reads a schedule for TrackInventory and returns the
+// DECODED workflow request alongside the full schedule description (spec, policy,
+// action timeouts, paused state, ...).
+//
+// The Temporal SDK returns a schedule action's input arguments as raw, undecoded
+// payloads, so this decodes the first argument back into the workflow's request
+// type. Pass the same data converter the client was built with when the input is
+// encrypted/custom-encoded (e.g. a codec/keyring converter); omit it to use the
+// default converter. This is the typed read-back counterpart to
+// UpsertScheduleTrackInventory — useful for exporting/backing up schedules.
+func (c *OrdersClient) DescribeScheduleTrackInventory(ctx context.Context, scheduleID string, dataConverter ...converter.DataConverter) (*TrackInventoryRequest, *client.ScheduleDescription, error) {
+	handle := c.client.ScheduleClient().GetHandle(ctx, scheduleID)
+	desc, err := handle.Describe(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	action, ok := desc.Schedule.Action.(*client.ScheduleWorkflowAction)
+	if !ok {
+		return nil, desc, fmt.Errorf("schedule %q action is not a workflow action", scheduleID)
+	}
+	if len(action.Args) == 0 {
+		return nil, desc, fmt.Errorf("schedule %q has no input arguments", scheduleID)
+	}
+	payload, ok := action.Args[0].(*v1.Payload)
+	if !ok {
+		return nil, desc, fmt.Errorf("schedule %q input argument is not a raw payload (already decoded?)", scheduleID)
+	}
+
+	dc := converter.GetDefaultDataConverter()
+	if len(dataConverter) > 0 && dataConverter[0] != nil {
+		dc = dataConverter[0]
+	}
+
+	req := new(TrackInventoryRequest)
+	if err := dc.FromPayload(payload, req); err != nil {
+		return nil, desc, fmt.Errorf("decoding schedule %q input: %w", scheduleID, err)
+	}
+	return req, desc, nil
 }
 
 // DeleteScheduleTrackInventory deletes a schedule for TrackInventory

--- a/internal/renderer/renderer_test.go
+++ b/internal/renderer/renderer_test.go
@@ -16,6 +16,8 @@ func TestTemplatesParse(t *testing.T) {
 		"TemporalWorkflow":        func(name string) string { return "" },
 		"TemporalActivity":        func(name string) string { return "" },
 		"Temporal":                func(name string) string { return "" },
+		"TemporalConverter":       func(name string) string { return "" },
+		"TemporalCommon":          func(name string) string { return "" },
 		"Context":                 func() string { return "" },
 		"Time":                    func(name string) string { return "" },
 		"Fmt":                     func(name string) string { return "" },

--- a/internal/renderer/templates/service.tmpl
+++ b/internal/renderer/templates/service.tmpl
@@ -406,6 +406,47 @@ func (c *{{.Service.GetClientName}}) GetSchedule{{.GoName}}(ctx {{Context}}, sch
 	return c.client.ScheduleClient().GetHandle(ctx, scheduleID)
 }
 
+// DescribeSchedule{{.GoName}} reads a schedule for {{.GoName}} and returns the
+// DECODED workflow request alongside the full schedule description (spec, policy,
+// action timeouts, paused state, ...).
+//
+// The Temporal SDK returns a schedule action's input arguments as raw, undecoded
+// payloads, so this decodes the first argument back into the workflow's request
+// type. Pass the same data converter the client was built with when the input is
+// encrypted/custom-encoded (e.g. a codec/keyring converter); omit it to use the
+// default converter. This is the typed read-back counterpart to
+// UpsertSchedule{{.GoName}} — useful for exporting/backing up schedules.
+func (c *{{.Service.GetClientName}}) DescribeSchedule{{.GoName}}(ctx {{Context}}, scheduleID string, dataConverter ...{{TemporalConverter "DataConverter"}}) (*{{QualifiedGoIdent .Input.GoIdent}}, *{{TemporalClient "ScheduleDescription"}}, error) {
+	handle := c.client.ScheduleClient().GetHandle(ctx, scheduleID)
+	desc, err := handle.Describe(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	action, ok := desc.Schedule.Action.(*{{TemporalClient "ScheduleWorkflowAction"}})
+	if !ok {
+		return nil, desc, {{Fmt "Errorf"}}("schedule %q action is not a workflow action", scheduleID)
+	}
+	if len(action.Args) == 0 {
+		return nil, desc, {{Fmt "Errorf"}}("schedule %q has no input arguments", scheduleID)
+	}
+	payload, ok := action.Args[0].(*{{TemporalCommon "Payload"}})
+	if !ok {
+		return nil, desc, {{Fmt "Errorf"}}("schedule %q input argument is not a raw payload (already decoded?)", scheduleID)
+	}
+
+	dc := {{TemporalConverter "GetDefaultDataConverter"}}()
+	if len(dataConverter) > 0 && dataConverter[0] != nil {
+		dc = dataConverter[0]
+	}
+
+	req := new({{QualifiedGoIdent .Input.GoIdent}})
+	if err := dc.FromPayload(payload, req); err != nil {
+		return nil, desc, {{Fmt "Errorf"}}("decoding schedule %q input: %w", scheduleID, err)
+	}
+	return req, desc, nil
+}
+
 // DeleteSchedule{{.GoName}} deletes a schedule for {{.GoName}}
 {{- if .Comment}}
 //

--- a/internal/tmpl/funcs.go
+++ b/internal/tmpl/funcs.go
@@ -20,6 +20,8 @@ func FuncMap(gf *protogen.GeneratedFile) template.FuncMap {
 		"TemporalWorkflow":        func(name string) string { return qualifiedTemporalIdent(gf, "go.temporal.io/sdk/workflow", name) },
 		"TemporalActivity":        func(name string) string { return qualifiedTemporalIdent(gf, "go.temporal.io/sdk/activity", name) },
 		"Temporal":                func(name string) string { return qualifiedTemporalIdent(gf, "go.temporal.io/sdk/temporal", name) },
+		"TemporalConverter":       func(name string) string { return qualifiedTemporalIdent(gf, "go.temporal.io/sdk/converter", name) },
+		"TemporalCommon":          func(name string) string { return qualifiedTemporalIdent(gf, "go.temporal.io/api/common/v1", name) },
 		"Context":                 func() string { return qualifiedIdent(gf, "context", "Context") },
 		"Time":                    func(name string) string { return qualifiedIdent(gf, "time", name) },
 		"Fmt":                     func(name string) string { return qualifiedIdent(gf, "fmt", name) },


### PR DESCRIPTION
## Why this is needed

The plugin generates the whole per-workflow schedule surface — `CreateScheduleX`, `GetScheduleX`, `DeleteScheduleX`, `PauseScheduleX`, `UnpauseScheduleX`, `ListScheduleX`, `UpsertScheduleX` — **except a typed way to read a schedule's input back**.

- `GetScheduleX` only returns the raw SDK `client.ScheduleHandle`.
- When you `handle.Describe(ctx)`, the SDK hands the schedule action's input args back as **undecoded `*commonpb.Payload`** (it can't know the type).

So today, reading a schedule's input means the caller reaches into `desc.Schedule.Action.(*client.ScheduleWorkflowAction).Args[0].(*commonpb.Payload)` and `FromPayload`s it into the request type **by hand** — untyped, easy to get wrong, and unavoidable when the input is **codec/keyring-encrypted** (the payload is opaque without the converter).

This came up building schedule **export/backup** tooling in `temporal-workers`: to back up the encrypted cert-renewal schedules I had to hand-roll exactly that decode, per repo. It belongs in the generator — the plugin already knows the workflow's request type.

## What it adds

A generated typed read-back:

```go
func (c *OrdersClient) DescribeScheduleProcessOrder(
    ctx context.Context, scheduleID string,
    dataConverter ...converter.DataConverter,
) (*ProcessOrderRequest, *client.ScheduleDescription, error)
```

- Returns the **decoded request** plus the **full `*client.ScheduleDescription`** (spec, overlap/catchup policy, action timeouts, paused state) — everything needed to round-trip a schedule.
- The data converter is **variadic** because the SDK doesn't expose the client's own converter: omit it for the default converter (plaintext inputs), pass your keyring/codec converter for encrypted inputs. This is the one honest wrinkle — see below.

## Design note (converter arg)

Ideally `DescribeScheduleX` would reuse the client's data converter automatically, but `client.Client` doesn't expose it (it's stored internally with no accessor). So the helper takes it as an optional trailing arg. Alternative would be capturing a converter in `NewXClient` — happy to switch if you'd rather store it on the client; the variadic form keeps the constructor unchanged.

## Implementation

- `internal/tmpl/funcs.go` — two package helpers (`TemporalConverter`, `TemporalCommon`).
- `internal/renderer/templates/service.tmpl` — emit `DescribeScheduleX` right after `GetScheduleX`.
- `internal/renderer/renderer_test.go` — register the new helpers in the parse-test stub.
- `example/` regenerated; **`example/e2e/TestDescribeScheduleRoundTrip`** upserts a `ProcessOrder` schedule with a real request, describes it, and asserts the decoded request matches + the description surfaces the spec.

## Verification

- `make build gen verify-examples` — regenerates + builds all four example workflows' `DescribeScheduleX`.
- Unit tests pass. `TestDescribeScheduleRoundTrip` **passes** against a real Temporal (0.03s standalone).
- Heads-up (pre-existing, not this PR): the whole schedule e2e suite is flaky on the bundled `temporalio/server:1.31.0` — the *first* `DescribeSchedule` after a cold start times out at ~10s (1.31's new matcher / scheduler-query cache warmup), so running the schedule tests as a batch fails the first one (`TestScheduleCRUD` included); they pass individually / once warm. Worth a separate look (TestMain warmup or a version pin).
